### PR TITLE
[CurlTransport] CURLOPT_SSLVERSION and CURLOPT_SSL_CIPHER_LIST can be…

### DIFF
--- a/src/CurlTransport.php
+++ b/src/CurlTransport.php
@@ -41,6 +41,14 @@ class CurlTransport implements TransportInterface {
     public function send(RequestInterface $request, ResponseInterface $response) {
         $ch = curl_init();
 
+        // If the PHP7 SSL constant is defined, going with that; otherwise, using the
+        // deprecated SSL setting.
+        if (defined(CURL_SSLVERSION_TLSv1)) {
+            curl_setopt($ch, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1);
+        } else {
+            curl_setopt($ch, CURLOPT_SSL_CIPHER_LIST, 'TLSv1');
+        }
+
         // Applying custom options to resource.
         // Using a foreach loop to make sure remaining options are applied in
         // case of an errorous option/value somewhere in between.
@@ -50,14 +58,6 @@ class CurlTransport implements TransportInterface {
 
         // Returning response string instead of putting it out directly.
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
-
-        // If the PHP7 SSL constant is defined, going with that; otherwise, using the
-        // deprecated SSL setting.
-        if (defined(CURL_SSLVERSION_TLSv1)) {
-            curl_setopt($ch, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1);
-        } else {
-            curl_setopt($ch, CURLOPT_SSL_CIPHER_LIST, 'TLSv1');
-        }
 
         // Recording request headers too.
         curl_setopt($ch, CURLINFO_HEADER_OUT, TRUE);


### PR DESCRIPTION
… overwritten through Transport::$_options.